### PR TITLE
bug 1246151 - Tweak the rewrite rules to fix an issue fetching symbols for the `firefox` binary

### DIFF
--- a/apache_app.conf
+++ b/apache_app.conf
@@ -4,17 +4,11 @@ LoadModule ssl_module libexec/mod_ssl.so
 SSLProxyEngine on
 RewriteEngine on
 RewriteMap toupper int:toupper
-#Bug 660932
-RewriteRule ^/firefox/(.+?)/([a-fA-F\d]*)/(.*) /firefox/$1/${toupper:$2}/$3
-RewriteRule ^/firefox/(.*)$ https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/$1 [P]
-RewriteRule ^/seamonkey/(.*)$ https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/$1 [P]
-RewriteRule ^/sunbird/(.*)$ https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/$1 [P]
-RewriteRule ^/thunderbird/(.*)$ https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/$1 [P]
-RewriteRule ^/xulrunner/(.*)$ https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/$1 [P]
-RewriteRule ^/fennec/(.*)$ https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/$1 [P]
-RewriteRule ^/b2g/(.*)$ https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/$1 [P]
+# Rewrite old app-specific URLs to strip off the app.
+RewriteRule ^/(firefox|seamonkey|sunbird|thunderbird|xulrunner|fennec|b2g)/(.+)/([a-fA-F\d]+)/(.+)$ /$2/$3/$4 [P]
+# Send stray GETs of the root to MDN.
 RewriteRule ^/$ https://developer.mozilla.org/en/Using_the_Mozilla_symbol_server
-# symbols are now in a flat namespace
 # support "http://symbols.mozilla.org/" as the symbol server URL.
+# See bug 414852 and bug 660932 for the reasoning behind the toupper.
 RewriteRule ^/(.+?)/([a-fA-F\d]*)/(.*) /$1/${toupper:$2}/$3
 RewriteRule ^/(.*)$ https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/$1 [P]

--- a/test.py
+++ b/test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+#
+# Any copyright is dedicated to the Public Domain.
+# http://creativecommons.org/publicdomain/zero/1.0/
+#
+# Test that some symbol server requests work. Run this script with
+# a URL as the first commandline argument to point it at a different instance.
+
+# NOTE: be sure to only use symbols that aren't going to get removed from
+# the symbol server. The URLs in use here are all from Firefox 18.0.2.
+
+import os
+import sys
+import unittest
+import urllib2
+import urlparse
+
+class TestSymbolServer(unittest.TestCase):
+    SERVER = 'http://symbols.mozilla.org/'
+
+    def check(self, url, first_line=None):
+        full_url = urlparse.urljoin(self.SERVER, url)
+        req = urllib2.Request(full_url)
+        if first_line is None:
+            # Do a HEAD if we don't care about the data.
+            req.get_method = lambda : 'HEAD'
+        res = urllib2.urlopen(full_url)
+        # If we ever make symbols.mo return redirects instead of proxying,
+        # this will have to change. Maybe just require `requests`.
+        self.assertEqual(res.getcode(), 200)
+        if first_line is not None:
+            self.assertEqual(res.readline().rstrip(), first_line)
+
+    def test_basic(self):
+        self.check('/firefox.pdb/448794C699914DB8A8F9B9F88B98D7412/firefox.sym',
+                   'MODULE windows x86 448794C699914DB8A8F9B9F88B98D7412 firefox.pdb')
+
+    # Just for sanity, make sure that requests for native debug symbols work
+    # for Windows/Linux/Mac symbols.
+    def test_basic_pdb(self):
+        self.check('/firefox.pdb/448794C699914DB8A8F9B9F88B98D7412/firefox.pd_')
+
+    def test_basic_dbg(self):
+        self.check('libxul.so/20BC1801B0B1864324D3B9E933328A170/libxul.so.dbg.gz')
+
+    def test_basic_dsym(self):
+        self.check('XUL/E3532A114F1C37E2AF567D8E6975F80C0/XUL.dSYM.tar.bz2')
+
+    def test_mixed_case(self):
+        'bug 660932, bug 414852'
+        self.check('/firefox.pdb/448794c699914db8a8f9b9f88b98d7412/firefox.sym',
+                   'MODULE windows x86 448794C699914DB8A8F9B9F88B98D7412 firefox.pdb')
+
+    def test_old_firefox_prefix(self):
+        self.check('/firefox/firefox.pdb/448794C699914DB8A8F9B9F88B98D7412/firefox.sym',
+                   'MODULE windows x86 448794C699914DB8A8F9B9F88B98D7412 firefox.pdb')
+
+    def test_old_thunderbird_prefix(self):
+        # Yes, this looks dumb.
+        self.check('/thunderbird/firefox.pdb/448794C699914DB8A8F9B9F88B98D7412/firefox.sym',
+                   'MODULE windows x86 448794C699914DB8A8F9B9F88B98D7412 firefox.pdb')
+
+    def test_firefox_without_prefix(self):
+        '''
+        bug 1246151 - The firefox binary on Linux/Mac is just named `firefox`,
+        so make sure the rewrite rules to strip the app name don't
+        break downloading these files.
+        '''
+        self.check('/firefox/946C0C63132015DD88CA2EFCBB9AC4C70/firefox.sym',
+                   'MODULE Linux x86_64 946C0C63132015DD88CA2EFCBB9AC4C70 firefox')
+
+    def test_firefox_without_prefix(self):
+        '''
+        bug 1246151 - The firefox binary on Linux/Mac is just named `firefox`,
+        so make sure the rewrite rules to strip the app name don't
+        break downloading these files.
+        '''
+        self.check('/firefox/946C0C63132015DD88CA2EFCBB9AC4C70/firefox.sym',
+                   'MODULE Linux x86_64 946C0C63132015DD88CA2EFCBB9AC4C70 firefox')
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1 and sys.argv[1].startswith('http'):
+        TestSymbolServer.SERVER = sys.argv.pop(1)
+    unittest.main()


### PR DESCRIPTION
The Firefox binary on Linux/Mac is just named `firefox`, which means that
fetching symbols for it using `http://symbols.mozilla.org/` as a symbol
server URL winds up getting caught by the rewrite rule that handles the old
`http://symbols.mozilla.org/firefox` path, like:

```
/firefox/946C0C63132015DD88CA2EFCBB9AC4C70/firefox.sym
-> /946C0C63132015DD88CA2EFCBB9AC4C70/firefox.sym
-> 404
```

This changes the rewrite rules to be a bit more strict in what they match, so
that only things that look like valid symbol server requests starting with
the old app name prefix get rewritten.

I also combined all the app-prefix-rewrites into a single rule and pruned
an unnecessary extra toupper rewrite rule.

Finally, I added a little script to run tests against the deployed server
to sanity check that I wasn't breaking anything. `test_firefox_without_prefix`
tests the bug at hand here, it fails against http://symbols.mozilla.org/
currently but passes against my test instance.

I have a test instance running at https://quiet-caverns-66913.herokuapp.com/, you can run the tests against it with `python test.py https://quiet-caverns-66913.herokuapp.com/`.
