### PR TITLE
Change rewrite to use s3-website endpoint

### DIFF
--- a/apache_app.conf
+++ b/apache_app.conf
@@ -11,4 +11,4 @@ RewriteRule ^/$ https://developer.mozilla.org/en/Using_the_Mozilla_symbol_server
 # support "http://symbols.mozilla.org/" as the symbol server URL.
 # See bug 414852 and bug 660932 for the reasoning behind the toupper.
 RewriteRule ^/(.+?)/([a-fA-F\d]*)/(.*) /$1/${toupper:$2}/$3
-RewriteRule ^/(.*)$ https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/$1 [P]
+RewriteRule ^/(.*)$ http://org.mozilla.crash-stats.symbols-public.s3-website-us-west-2.amazonaws.com/v1/$1 [P]


### PR DESCRIPTION
I have created an `org.mozilla.crash-stats.symbols-public-try` bucket. I have set up a redirect for the `org.mozilla.crash-stats.symbols-public` bucket's website endpoint so that if a 404 is returned, it will redirect to the requested key in `org.mozilla.crash-stats.symbols-public-try`, and then if nothing is found there, redirect to a [404 page with a brief explanation](http://org.mozilla.crash-stats.symbols-public-try.s3-us-west-2.amazonaws.com/404.html).

For reasons unknown, this endpoint doesn't work with SSL. This could be fixed by using Cloudfront, but Cloudfront is fussy about buckets with periods in their names, so I'm putting that off.

@rhelmer r?
@luser